### PR TITLE
Small fixes for GridEntry generators

### DIFF
--- a/generators/gridEntry/templates/_entry/entry.component.spec.ts
+++ b/generators/gridEntry/templates/_entry/entry.component.spec.ts
@@ -165,7 +165,7 @@ describe('<%= moduleNameNoDash %>: <%= moduleNameNoDash %><%= sectionNameNoDashS
 			};
 			createComponent();
 			gridEntryOptions.getEntryForEdit(gridView).subscribe();
-			expect(agent.get<%= sectionNameNoDashSingular %>).toHaveBeenCalledWith(123, 234);
+			expect(agent.get<%= sectionNameNoDashSingular %>Detail).toHaveBeenCalledWith(123, 234);
 		}));
 
 		describe('createField', () => {

--- a/generators/gridEntry/templates/_entry/entry.component.ts
+++ b/generators/gridEntry/templates/_entry/entry.component.ts
@@ -38,7 +38,7 @@ import {
 } from '../../../contracts/<%= moduleName %>-<%= sectionNameSingular %>.interface';
 import {
     <%= moduleNameNoDash %>Agent
-} from '../../../shared/<%= moduleName %>.agent';
+} from '../../../<%= moduleName %>.agent';
 
 @Component({
 	selector: '<%= moduleName %>-<%= sectionNameSingular %>s-entry',


### PR DESCRIPTION
Removed shared from agent path for the entry.component.ts, changed getSubmodule to getSubmoduleDetail in the entry.component.spec.ts to follow what is generated in the entry.component.spec for getEntryForEdit.